### PR TITLE
fix(vercel): remove env vars from vercel actions

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up PNPM
+      - name: 🏗 Set up PNPM
         uses: pnpm/action-setup@v2.2.2
         with:
           version: latest
           run_install: true
-      - name: Set up Node.js
+      - name: 🏗 Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "16"

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -27,7 +27,5 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - name: 🏗 Build
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
       - name: ⬆️ Deploy
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel-prod.yml
+++ b/.github/workflows/vercel-prod.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up PNPM
+      - name: 🏗 Set up PNPM
         uses: pnpm/action-setup@v2.2.2
         with:
           version: latest
           run_install: true
-      - name: Set up Node.js
+      - name: 🏗 Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "16"

--- a/.github/workflows/vercel-prod.yml
+++ b/.github/workflows/vercel-prod.yml
@@ -27,11 +27,5 @@ jobs:
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: 🏗 Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       - name: ⬆️ Deploy
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Overview
This PR removes the imported environment variables in the Vercel deployment actions. These are not needed because `vercel pull` includes the env vars.