### PR TITLE
[PON-20] fix: use Person icon as avatar fallback

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,19 +1,24 @@
-import * as Avatar from "@radix-ui/react-avatar";
+import * as RadixAvatar from "@radix-ui/react-avatar";
+import { PersonIcon } from "@radix-ui/react-icons";
+import { ReactNode } from "react";
 import styles from "./Avatar.module.css";
 
 type AvatarProps = {
   alt: string;
   delayMs?: number;
-  fallback: string;
+  fallback?: ReactNode;
   src: string;
 };
-const AvatarDemo = ({ alt, delayMs, fallback, src }: AvatarProps) => (
-  <Avatar.Root className={styles.AvatarRoot}>
-    <Avatar.Image className={styles.AvatarImage} src={src} alt={alt} />
-    <Avatar.Fallback className={styles.AvatarFallback} delayMs={delayMs || 600}>
-      {fallback}
-    </Avatar.Fallback>
-  </Avatar.Root>
+const Avatar = ({ alt, delayMs, fallback, src }: AvatarProps) => (
+  <RadixAvatar.Root className={styles.AvatarRoot}>
+    <RadixAvatar.Image className={styles.AvatarImage} src={src} alt={alt} />
+    <RadixAvatar.Fallback
+      className={styles.AvatarFallback}
+      delayMs={delayMs ?? 600}
+    >
+      {fallback ?? <PersonIcon />}
+    </RadixAvatar.Fallback>
+  </RadixAvatar.Root>
 );
 
-export default AvatarDemo;
+export default Avatar;

--- a/src/components/Header/AuthNavMenu/index.tsx
+++ b/src/components/Header/AuthNavMenu/index.tsx
@@ -14,11 +14,9 @@ import styles from "./AuthNavMenu.module.css";
 
 const Wrap = styled(NavMenuItem)`
   display: flex;
-  gap: 10px;
   border: 1px solid slateblue;
   border-radius: 50px;
   padding: 4px;
-  margin: -4px -4px 0 0;
 
   &:hover {
     box-shadow: 0px 2px 5px 0px slateblue;
@@ -47,11 +45,7 @@ const AuthNavMenu = () => {
 
   return (
     <Wrap data-testid="AuthenticatedMenu">
-      <Avatar
-        src={pictureUrl}
-        alt={session?.user?.name || ""}
-        fallback="My account"
-      />
+      <Avatar src={pictureUrl} alt={session?.user?.name || ""} />
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <button className={styles.IconButton} aria-label="account menu">


### PR DESCRIPTION
## What
This pull request fixes an issue where the _avatar_ in the navigation bar would read "My Account" when the user's avatar was not accessible, such as when the internet was not accessible. 

To solve this and future issues, the **Person** icon will be used as the default fallback for the `Avatar` component.